### PR TITLE
Adjust schedule row layout and controls

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -161,3 +161,70 @@ table.matlist .iconbtn:hover{filter:brightness(1.15)}
   .vrow .notes-cell{grid-column:1 / -1}
 }
 /* === fin patch === */
+
+/* === EP PATCH 2025: Layout filas horario === */
+.vrow{
+  display:grid;
+  gap:.75rem;
+  border:1px solid var(--line);
+  border-radius:.6rem;
+  padding:.75rem;
+  grid-template-columns:64px 170px 160px 1fr 1fr 1fr 1.5fr;
+  align-items:start;
+}
+.vrow .selcell{
+  grid-column:1;
+  display:flex;
+  flex-direction:column;
+  gap:.35rem;
+  align-items:center;
+}
+.vrow .time{
+  grid-column:2;
+  display:flex;
+  align-items:center;
+  gap:.45rem;
+}
+.time-label{
+  font-variant-numeric:tabular-nums;
+  font-weight:600;
+}
+.time-shift{
+  display:flex;
+  flex-direction:column;
+  gap:.25rem;
+}
+.time-shift .btn{
+  padding:.15rem .4rem;
+  line-height:1;
+}
+.duration-cell{grid-column:3;}
+.task-cell{grid-column:4;}
+.location-cell{grid-column:5;}
+.vehicle-cell{grid-column:6;}
+.materials-cell{grid-column:7;}
+.notes-cell{grid-column:1 / -1;}
+@media (max-width:1200px){
+  .vrow{
+    grid-template-columns:64px 150px 1fr 1fr;
+  }
+  .duration-cell{grid-column:3;}
+  .task-cell{grid-column:4;}
+  .location-cell{grid-column:3;}
+  .vehicle-cell{grid-column:4;}
+  .materials-cell{grid-column:1 / -1;}
+}
+@media (max-width:900px){
+  .vrow{
+    grid-template-columns:64px 1fr;
+  }
+  .vrow .time{grid-column:1 / -1;}
+  .duration-cell,
+  .task-cell,
+  .location-cell,
+  .vehicle-cell,
+  .materials-cell{
+    grid-column:1 / -1;
+  }
+}
+/* === Fin EP PATCH 2025 === */

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -41,11 +41,35 @@
       sel.appendChild(bSel); sel.appendChild(bDel); row.appendChild(sel);
 
       // Horario
-      row.appendChild(el("div","time", toHHMM(s.startMin)+"-"+toHHMM(s.endMin)));
+      const adjustTime=(delta)=>{
+        const list=getPersonSessions(pid); if(!list[idx]) return;
+        const step=Math.round(delta/5)*5; if(step===0) return;
+        if(idx===0){
+          const base=(state.horaInicial?.[pid] ?? list[0]?.startMin ?? 0);
+          const next=Math.max(0, base+step);
+          state.horaInicial[pid]=next;
+          rebaseTo(pid,next);
+          renderClient();
+          return;
+        }
+        const prev=list[idx-1]; if(!prev) return;
+        const prevDur=Math.max(5, (parseInt(prev.endMin||"0",10)||0) - (parseInt(prev.startMin||"0",10)||0));
+        const newDur=prevDur+step; if(newDur<5) return;
+        resizeSegment(pid, idx-1, newDur);
+        renderClient();
+      };
+      const timeCell=el("div","time time-cell");
+      const timeLabel=el("span","time-label", toHHMM(s.startMin)+"-"+toHHMM(s.endMin));
+      const timeShift=el("span","time-shift");
+      const timeUp=el("button","btn small","▲"); timeUp.onclick=(e)=>{ e.stopPropagation(); adjustTime(5); };
+      const timeDown=el("button","btn small","▼"); timeDown.onclick=(e)=>{ e.stopPropagation(); adjustTime(-5); };
+      timeShift.appendChild(timeUp); timeShift.appendChild(timeDown);
+      timeCell.appendChild(timeLabel); timeCell.appendChild(timeShift);
+      row.appendChild(timeCell);
 
-      
+
 // Duración
-const ddiv=el("div","param");
+const ddiv=el("div","param duration-cell");
 ddiv.innerHTML="<label>Duracion (min)</label>";
 const din=el("input","input");
 din.type="number"; din.min="5"; din.step="5";
@@ -65,7 +89,7 @@ ddiv.appendChild(din); ddiv.appendChild(box);
 row.appendChild(ddiv);
 
       // Tarea
-      const tdiv=el("div","param"); tdiv.innerHTML="<label>Tarea</label>";
+      const tdiv=el("div","param task-cell"); tdiv.innerHTML="<label>Tarea</label>";
       const tsel=el("select","input"); const t0=el("option",null,"- seleccionar -"); t0.value=""; tsel.appendChild(t0);
       const allowMont=!!s.nextId; const allowDesm=!!s.prevId;
       state.taskTypes.forEach(t=>{
@@ -92,7 +116,7 @@ row.appendChild(ddiv);
       tdiv.appendChild(tsel); row.appendChild(tdiv);
 
       // Localización (bloqueada salvo primera o transporte)
-      const ldiv=el("div","param");
+      const ldiv=el("div","param location-cell");
       if(idx===0 && s.taskTypeId!==TASK_TRANSP){
         ldiv.innerHTML="<label>Localizacion inicial</label>";
         const lsel=el("select","input"); const l0=el("option",null,"- seleccionar -"); l0.value=""; lsel.appendChild(l0);
@@ -112,7 +136,7 @@ row.appendChild(ddiv);
       row.appendChild(ldiv);
 
       // Vehiculo (solo Transporte)
-      const vdiv=el("div","param"); vdiv.innerHTML="<label>Vehiculo</label>";
+      const vdiv=el("div","param vehicle-cell"); vdiv.innerHTML="<label>Vehiculo</label>";
       if(s.taskTypeId===TASK_TRANSP){
         const vsel=el("select","input"); const v0=el("option",null,"- seleccionar -"); v0.value=""; vsel.appendChild(v0);
         state.vehicles.forEach(v=>{ const o=el("option",null,v.nombre); o.value=v.id; if(v.id===s.vehicleId) o.selected=true; vsel.appendChild(o); });
@@ -123,7 +147,7 @@ row.appendChild(ddiv);
       row.appendChild(vdiv);
 
       // Materiales + Vínculos
-      const mdiv=el("div","param"); mdiv.innerHTML="<label>Materiales</label>";
+      const mdiv=el("div","param materials-cell"); mdiv.innerHTML="<label>Materiales</label>";
       const bar=el("div","row");
       const bPrev=el("button","btn small","◀ Vincular PRE"); bPrev.onclick=(e)=>{ e.stopPropagation(); linkMode.active=true; linkMode.kind="prev"; linkMode.sourceId=s.id; renderClient(); };
       const bPost=el("button","btn small","Vincular POST ▶"); bPost.onclick=(e)=>{ e.stopPropagation(); linkMode.active=true; linkMode.kind="post"; linkMode.sourceId=s.id; renderClient(); };
@@ -185,7 +209,7 @@ row.appendChild(ddiv);
       row.appendChild(mdiv);
 
       // Notas
-      const ndiv=el("div","param"); ndiv.innerHTML="<label>Notas</label>";
+      const ndiv=el("div","param notes-cell"); ndiv.innerHTML="<label>Notas</label>";
       const ta=el("textarea","input"); ta.rows=3; ta.value=String(s.comentario||""); ta.placeholder="Comentarios de la accion";
       ta.oninput=()=>{ s.comentario=ta.value; touch(); autoGrow(ta); };
       setTimeout(()=>autoGrow(ta),0); ndiv.appendChild(ta); row.appendChild(ndiv);


### PR DESCRIPTION
## Summary
- align the schedule row grid so the task, location, vehicle, and material fields match the requested positioning
- add inline arrows next to the time display so the schedule can shift in five-minute increments like the duration control

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d16b63f80c832a9b9293df9aabf01b