### PR TITLE
Adjust schedule layout for transport rows

### DIFF
--- a/assets/app.bundle.js
+++ b/assets/app.bundle.js
@@ -343,6 +343,13 @@
     if(linkMode.active) banner(container);
 
     const list=getPersonSessions(pid);
+    const first=list[0];
+    if(first && first.taskTypeId===TASK_TRANSP){
+      first.taskTypeId=null;
+      first.vehicleId=null;
+      recomputeLocations(pid);
+      touch();
+    }
     if(!list.length){ container.appendChild(el("div","mini","No hay acciones.")); return; }
 
     const computeTransportFlow=(targetIdx)=>{
@@ -402,13 +409,15 @@
       const minus=el("button","icon-btn","−"); minus.title="Reducir duracion"; minus.onclick=(e)=>{ e.stopPropagation(); doResize(-5); };
       timeAdjust.appendChild(plus); timeAdjust.appendChild(minus);
       const timeDisplay=el("div","time-display");
-      timeDisplay.appendChild(range); timeDisplay.appendChild(timeAdjust);
+      const timeMain=el("div","time-main");
+      timeMain.appendChild(range); timeMain.appendChild(timeAdjust);
+      timeDisplay.appendChild(timeMain);
+      const durationHint=el("div","duration-hint","Duración: "+String(s.endMin-s.startMin)+" min");
+      timeDisplay.appendChild(durationHint);
       header.appendChild(bSel); header.appendChild(bDel); header.appendChild(timeDisplay);
       sel.appendChild(header);
 
-      const durationHint=el("div","duration-hint","Duración: "+String(s.endMin-s.startMin)+" min");
       const timeTools=el("div","time-tools");
-      timeTools.appendChild(durationHint);
       const linkHints=el("div","link-hints");
       const formatSessionLabel=(info,fallback)=> info? `${info.pid} · #${info.index+1}` : (fallback? `#${fallback}` : "#?");
       const selfInfo={pid,index:idx,session:s};
@@ -440,8 +449,10 @@
           addLinkHint("Vinculación POST", `${formatSessionLabel(other,s.nextId)} → ${formatSessionLabel(selfInfo,s.id)}`, ()=>{ clearPrevLink(s.nextId); renderClient(); }, extras);
         }
       }
-      if(linkHints.childElementCount) timeTools.appendChild(linkHints);
-      sel.appendChild(timeTools);
+      if(linkHints.childElementCount){
+        timeTools.appendChild(linkHints);
+        sel.appendChild(timeTools);
+      }
 
       const linkWrap=el("div","link-controls under-slot");
       const bPrev=el("button","icon-btn ghost","◀"); bPrev.title="Vincular PRE"; bPrev.onclick=(e)=>{ e.stopPropagation(); linkMode.active=true; linkMode.kind="prev"; linkMode.sourceId=s.id; renderClient(); };
@@ -458,6 +469,7 @@
         const isM=t.id===TASK_MONTAGE, isD=t.id===TASK_DESMONT;
         if(isM && !allowMont) return;
         if(isD && !allowDesm) return;
+        if(idx===0 && t.id===TASK_TRANSP) return;
         const o=el("option",null,t.nombre); o.value=t.id; if(t.id===s.taskTypeId) o.selected=true; tsel.appendChild(o);
       });
       tsel.onchange=()=>{
@@ -486,6 +498,7 @@
         lsel.onchange=()=>{ s.locationId=lsel.value||null; recomputeLocations(pid); touch(); renderVerticalEditor(container,pid); };
         ldiv.appendChild(lsel);
       }else if(s.taskTypeId===TASK_TRANSP){
+        ldiv.classList.add("stacked");
         ldiv.innerHTML="<label>Destino</label>";
         const lsel=el("select","input"); const l0=el("option",null,"- seleccionar -"); l0.value=""; lsel.appendChild(l0);
         state.locations.forEach(l=>{ const o=el("option",null,l.nombre); o.value=l.id; if(l.id===s.locationId) o.selected=true; lsel.appendChild(o); });

--- a/assets/app.css
+++ b/assets/app.css
@@ -32,6 +32,9 @@ textarea{min-height:96px;resize:vertical}
 .param{display:flex;gap:.4rem;align-items:center;min-width:0}
 .param label{white-space:nowrap}
 .param .input, .param select, .param textarea{flex:1 1 auto; width:100%; min-width:0}
+.param.stacked{flex-direction:column;align-items:flex-start;gap:.4rem}
+.param.stacked label{margin-bottom:.05rem}
+.param.stacked .input,.param.stacked select,.param.stacked textarea{width:100%}
 
 .mattable{width:100%;border-collapse:collapse;margin-top:.5rem}
 .mattable th,.mattable td{border:1px solid #1f2937;padding:.3rem .4rem}
@@ -153,8 +156,18 @@ table.matlist td.act{width:120px}
 }
 .time-display{
   display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:.4rem;
+}
+.time-main{
+  display:flex;
   align-items:center;
   gap:.45rem;
+}
+.time-display .duration-hint{
+  width:100%;
+  text-align:center;
 }
 .time-adjust{
   display:flex;
@@ -205,6 +218,9 @@ table.matlist td.act{width:120px}
 }
 .transport-flow{
   margin-top:.25rem;
+  width:100%;
+  text-align:left;
+  line-height:1.35;
 }
 .task-cell{grid-column:2;}
 .location-cell{grid-column:3;}


### PR DESCRIPTION
## Summary
- Prevent the first schedule row from being assigned Transporte and clear legacy selections when needed
- Center the duration text beneath the time controls for each row
- Stack transport destination details so the origin/destination hint sits below the Destino selector

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d316a65964832abf2c73cbde1c9d8e