### PR TITLE
Ensure person tabs return to schedule view

### DIFF
--- a/assets/app.bundle.js
+++ b/assets/app.bundle.js
@@ -1403,7 +1403,12 @@
     const mk=(p,isActive)=>{
       const b=el("button","tab"+(isActive?" active":""), p.nombre);
       b.dataset.pid=p.id;
-      b.onclick=()=>{ state.project.view.lastTab=p.id; renderClient(); personTabs(); };
+      b.onclick=()=>{
+        showOnly("clienteView");
+        state.project.view.lastTab=p.id;
+        renderClient();
+        personTabs();
+      };
       tabs.appendChild(b);
     };
     const activeId = (state.project.view.lastTab==="CLIENTE"||state.project.view.lastTab==="cliente") ? "CLIENTE" : state.project.view.lastTab;
@@ -1431,7 +1436,12 @@
       const chip=el("div","staffchip");
       const nameEl = el("span",null,p.nombre);
       nameEl.style.cursor="pointer";
-      nameEl.onclick=()=>{ state.project.view.lastTab=p.id; renderClient(); personTabs(); };
+      nameEl.onclick=()=>{
+        showOnly("clienteView");
+        state.project.view.lastTab=p.id;
+        renderClient();
+        personTabs();
+      };
       chip.appendChild(nameEl);
       const del=el("button","del","X"); del.title="Eliminar"; del.onclick=()=>{ if((state.sessions?.[p.id]||[]).length){ alert("No se puede eliminar: tiene acciones."); return; } state.staff=state.staff.filter(x=>x.id!==p.id); touch(); personTabs(); renderClient(); renderStaffList(); };
       chip.appendChild(del); box.appendChild(chip);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,7 +11,12 @@
     const mk=(p,isActive)=>{
       const b=el("button","tab"+(isActive?" active":""), p.nombre);
       b.dataset.pid=p.id;
-      b.onclick=()=>{ state.project.view.lastTab=p.id; renderClient(); personTabs(); };
+      b.onclick=()=>{
+        showOnly("clienteView");
+        state.project.view.lastTab=p.id;
+        renderClient();
+        personTabs();
+      };
       tabs.appendChild(b);
     };
     const activeId = (state.project.view.lastTab==="CLIENTE"||state.project.view.lastTab==="cliente") ? "CLIENTE" : state.project.view.lastTab;
@@ -39,7 +44,12 @@
       const chip=el("div","staffchip");
       const nameEl = el("span",null,p.nombre);
       nameEl.style.cursor="pointer";
-      nameEl.onclick=()=>{ state.project.view.lastTab=p.id; renderClient(); personTabs(); };
+      nameEl.onclick=()=>{
+        showOnly("clienteView");
+        state.project.view.lastTab=p.id;
+        renderClient();
+        personTabs();
+      };
       chip.appendChild(nameEl);
       const del=el("button","del","X"); del.title="Eliminar"; del.onclick=()=>{ if((state.sessions?.[p.id]||[]).length){ alert("No se puede eliminar: tiene acciones."); return; } state.staff=state.staff.filter(x=>x.id!==p.id); touch(); personTabs(); renderClient(); renderStaffList(); };
       chip.appendChild(del); box.appendChild(chip);


### PR DESCRIPTION
## Summary
- show the schedule view when selecting the client tab or staff entries so the schedule is displayed even after browsing catalogs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d40cff32ec832a88c2ea84cc9e7d6d