### PR TITLE
Rework client schedule workflow and staff assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# event-planer
+# Event Planer
+
+## Horario del cliente y staff
+
+1. Crea un nuevo hito desde el catálogo de la vista principal y completa su hora y localización.
+2. Desde la tarjeta del hito añade tareas `Pre`, `Paralela` o `Post`, indicando duración, ventanas y ubicación.
+3. Asigna materiales y miembros del staff desde la misma tarjeta.
+4. Define una hora exacta para cada tarea del staff cuando quieras que aparezca en su horario.
+5. Consulta los resultados en las vistas de Gantt, tarjetas o resumen para revisar conflictos y tareas sin hora.

--- a/assets/app.css
+++ b/assets/app.css
@@ -6,6 +6,8 @@ html,body{height:100%;margin:0;background:#0b1220;color:#e5e7eb;font:14px/1.4 ui
 .btn.small{font-size:12px;padding:.25rem .5rem}
 .btn.danger{background:#7f1d1d;border-color:#991b1b}
 .btn.chip{background:#e5e7eb;color:#111827;border-color:#e5e7eb}
+.muted{color:#94a3b8}
+.btn.full{width:100%;display:flex;justify-content:center;align-items:center}
 .vlist{display:flex;flex-direction:column;gap:.6rem}
 .grid{display:grid;grid-template-columns:300px 1fr}
 .sidebar{border-right:1px solid #0f172a;background:#0b1220}
@@ -106,6 +108,51 @@ table.matlist{width:100%;border-collapse:collapse;margin-top:.35rem}
 table.matlist th,table.matlist td{border-bottom:1px solid #1f2937;padding:.25rem .35rem;text-align:left}
 table.matlist td.qty{width:90px}
 table.matlist td.act{width:120px}
+
+/* === Nuevo layout horario cliente === */
+.client-layout{display:grid;grid-template-columns:minmax(260px,320px) 1fr;gap:1.4rem}
+.task-catalog{display:flex;flex-direction:column;gap:1rem}
+.catalog-toolbar{display:flex}
+.catalog-section{background:#0f172a;border:1px solid #1f2937;border-radius:.75rem;padding:.8rem;display:flex;flex-direction:column;gap:.55rem}
+.catalog-title{font-size:.9rem;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:#94a3b8}
+.catalog-item{display:flex;flex-direction:column;gap:.2rem;align-items:flex-start;background:#0b1220;border:1px solid #1f2937;border-radius:.65rem;padding:.6rem .75rem;color:#e5e7eb;text-align:left;cursor:pointer}
+.catalog-item .mini{margin-top:.1rem}
+.catalog-item.active{border-color:#3b82f6;box-shadow:0 0 0 1px #3b82f6}
+.catalog-item:hover{border-color:#3b82f6;}
+.relation-tag{margin-top:.25rem;font-size:.75rem;text-transform:uppercase;letter-spacing:.1em;color:#cbd5f5}
+.task-card{display:flex;flex-direction:column;gap:1rem;background:#0b1220;border:1px solid #1f2937;border-radius:.9rem;padding:1rem 1.2rem}
+.task-header{display:flex;justify-content:space-between;align-items:flex-start;gap:.75rem;flex-wrap:wrap}
+.task-title{margin:0;font-size:1.4rem}
+.task-chips{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap}
+.relation-chip{background:#1d4ed8;color:#e0e7ff;padding:.25rem .6rem;border-radius:.65rem;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
+.status-chip{padding:.25rem .6rem;border-radius:.65rem;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
+.status-chip.ok{background:#166534;color:#dcfce7}
+.status-chip.warn{background:#7f1d1d;color:#fee2e2}
+.task-breadcrumb{display:flex;flex-wrap:wrap;gap:.35rem;align-items:center;font-size:.85rem}
+.crumb{background:#111827;border:1px solid #1f2937;color:#e5e7eb;padding:.25rem .6rem;border-radius:.55rem;cursor:pointer}
+.crumb:disabled{opacity:.6;cursor:default}
+.crumb-sep{opacity:.6}
+.task-form{display:flex;flex-direction:column;gap:.75rem}
+.field-row{display:flex;flex-direction:column;gap:.35rem}
+.field-row label{font-weight:600;font-size:.85rem;color:#cbd5f5}
+.field-row .input, .field-row select, .field-row textarea{width:100%}
+.materials-section,.staff-section,.child-block{border-top:1px solid #1f2937;padding-top:.75rem;display:flex;flex-direction:column;gap:.6rem}
+.materials-list{display:flex;flex-direction:column;gap:.45rem}
+.material-row{display:flex;gap:.45rem;align-items:center}
+.staff-picker{display:flex;flex-wrap:wrap;gap:.45rem}
+.staff-toggle{background:#111827;border:1px solid #1f2937;color:#e5e7eb;border-radius:.6rem;padding:.35rem .65rem;cursor:pointer}
+.staff-toggle.active{background:#047857;border-color:#059669;color:#fff}
+.child-header{display:flex;justify-content:space-between;align-items:center}
+.child-list{display:flex;flex-wrap:wrap;gap:.45rem}
+.child-item{background:#0f172a;border:1px solid #1f2937;color:#e5e7eb;border-radius:.6rem;padding:.35rem .6rem;cursor:pointer}
+.child-item.pending{border-color:#f97316;color:#fdba74}
+.empty-card{padding:2rem;border:1px dashed #1f2937;border-radius:.75rem;text-align:center;color:#94a3b8}
+.materials-section .mini,.staff-section .mini,.child-block .mini{color:#94a3b8}
+.check{display:flex;align-items:center;gap:.35rem;font-size:.85rem;color:#cbd5f5}
+
+@media (max-width:1100px){
+  .client-layout{grid-template-columns:1fr}
+}
 
 /* === EP PATCH 2025: Layout filas horario renovado === */
 .vrow{

--- a/assets/new-ui.js
+++ b/assets/new-ui.js
@@ -1,0 +1,721 @@
+
+(function(){
+  "use strict";
+
+  const RELATION_LABEL = {
+    milestone: "Hito",
+    pre: "Pre",
+    post: "Post",
+    parallel: "Paralela"
+  };
+  const RELATION_ORDER = { milestone:0, pre:1, parallel:2, post:3 };
+  const RELATION_COLOR = {
+    milestone: "#2563eb",
+    pre: "#a855f7",
+    post: "#f97316",
+    parallel: "#14b8a6"
+  };
+
+  let seq = 0;
+  const nextId = ()=>`T_${Date.now().toString(36)}${(++seq).toString(36)}`;
+
+  const originalEnsureDefaults = window.ensureDefaults || (()=>{});
+  const originalEnsureLinkFields = window.ensureLinkFields || (()=>{});
+
+  const ensureViewDefaults = ()=>{
+    state.project = state.project || {};
+    state.project.view = state.project.view || {};
+    state.project.view.lastTab = "CLIENTE";
+    if(typeof state.project.view.selectedTaskId === "undefined") state.project.view.selectedTaskId = null;
+  };
+
+  const toNumberOrNull = (value)=>{
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  };
+
+  const ensureMaterial = (m)=>({
+    materialTypeId: m?.materialTypeId || null,
+    cantidad: Number.isFinite(Number(m?.cantidad)) ? Number(m.cantidad) : 0
+  });
+
+  const applyTaskDefaults = (task)=>{
+    if(!task) return;
+    if(!task.id) task.id = nextId();
+    if(typeof task.structureParentId === "undefined") task.structureParentId = null;
+    if(!task.structureRelation){
+      task.structureRelation = task.structureParentId ? "pre" : "milestone";
+    }
+    if(typeof task.actionType === "undefined") task.actionType = window.ACTION_TYPE_NORMAL || "NORMAL";
+    task.materiales = Array.isArray(task.materiales) ? task.materiales.map(ensureMaterial) : [];
+    task.assignedStaffIds = Array.isArray(task.assignedStaffIds)
+      ? task.assignedStaffIds.filter(Boolean)
+      : (task.assignedStaffId ? [task.assignedStaffId] : []);
+    task.assignedStaffId = undefined;
+    if(typeof task.locationApplies === "undefined") task.locationApplies = true;
+    if(typeof task.locationId === "undefined") task.locationId = null;
+    if(typeof task.comentario !== "string") task.comentario = task.comentario ? String(task.comentario) : "";
+    task.startMin = toNumberOrNull(task.startMin);
+    task.endMin = toNumberOrNull(task.endMin);
+    task.durationMin = Number.isFinite(Number(task.durationMin)) ? Math.max(5, Math.round(Number(task.durationMin))) : null;
+    if(task.startMin != null && task.endMin != null){
+      task.durationMin = Math.max(5, task.endMin - task.startMin);
+    }
+    if(task.durationMin == null) task.durationMin = 60;
+    task.limitEarlyMin = toNumberOrNull(task.limitEarlyMin);
+    task.limitLateMin = toNumberOrNull(task.limitLateMin);
+  };
+
+  const ensureDuration = (task)=>{
+    if(!task) return;
+    if(task.startMin == null){
+      task.endMin = null;
+      return;
+    }
+    const dur = Math.max(5, Number(task.durationMin)||60);
+    task.durationMin = dur;
+    task.endMin = task.startMin + dur;
+  };
+
+  const getTaskList = ()=>{
+    state.sessions = state.sessions || {};
+    state.sessions.CLIENTE = state.sessions.CLIENTE || [];
+    const list = state.sessions.CLIENTE;
+    list.forEach(applyTaskDefaults);
+    list.forEach(ensureDuration);
+    return list;
+  };
+
+  const getTaskById = (id)=> getTaskList().find(t=>t.id===id) || null;
+  const getTaskChildren = (id)=> getTaskList().filter(t=>t.structureParentId===id);
+  const getRootTasks = ()=> getTaskList().filter(t=>!t.structureParentId);
+
+  const getBreadcrumb = (task)=>{
+    if(!task) return [];
+    const path=[];
+    let cur=task;
+    const lookup=new Map(getTaskList().map(t=>[t.id,t]));
+    while(cur){
+      path.unshift(cur);
+      if(!cur.structureParentId) break;
+      cur = lookup.get(cur.structureParentId) || null;
+    }
+    return path;
+  };
+
+  const hierarchyOrder = ()=>{
+    const order=new Map();
+    let i=0;
+    const visit=(node)=>{
+      order.set(node.id, i++);
+      getTaskChildren(node.id).forEach(child=>visit(child));
+    };
+    getRootTasks().sort((a,b)=>(a.startMin??0)-(b.startMin??0)).forEach(visit);
+    return order;
+  };
+
+  const isTaskComplete = (task)=>{
+    applyTaskDefaults(task);
+    const hasName = !!(task.actionName && task.actionName.trim());
+    const hasLocation = !task.locationApplies || !!task.locationId;
+    if(task.structureRelation === "milestone"){
+      return hasName && task.startMin != null && hasLocation;
+    }
+    const hasDuration = Number(task.durationMin) > 0;
+    if(task.structureRelation === "post"){
+      return hasName && hasDuration && task.limitLateMin != null && hasLocation;
+    }
+    if(task.structureRelation === "pre" || task.structureRelation === "parallel"){
+      return hasName && hasDuration && task.limitEarlyMin != null && hasLocation;
+    }
+    return hasName;
+  };
+
+  const syncStaffSessions = ()=>{
+    const list=getTaskList();
+    const byStaff=new Map();
+    list.forEach(task=>{
+      (task.assignedStaffIds||[]).forEach(id=>{
+        if(!id) return;
+        if(!byStaff.has(id)) byStaff.set(id, []);
+        byStaff.get(id).push(task);
+      });
+    });
+    (state.staff||[]).forEach(st=>{
+      const items = (byStaff.get(st.id) || []).slice().sort((a,b)=>{
+        const sa=a.startMin??Infinity;
+        const sb=b.startMin??Infinity;
+        return sa-sb;
+      });
+      state.sessions[st.id] = items;
+    });
+    Object.keys(state.sessions).forEach(pid=>{
+      if(pid!=="CLIENTE" && !(state.staff||[]).some(s=>s.id===pid)){
+        delete state.sessions[pid];
+      }
+    });
+  };
+
+  const touchTask = (task)=>{
+    applyTaskDefaults(task);
+    ensureDuration(task);
+    syncStaffSessions();
+    touch();
+  };
+
+  const createTask = ({ parentId=null, relation=null }={})=>{
+    const list=getTaskList();
+    const task={
+      id: nextId(),
+      structureParentId: parentId,
+      structureRelation: relation || (parentId?"pre":"milestone"),
+      actionName: "",
+      durationMin: 60,
+      limitEarlyMin: null,
+      limitLateMin: null,
+      locationId: null,
+      locationApplies: true,
+      materiales: [],
+      comentario: "",
+      assignedStaffIds: [],
+      startMin: parentId?null:(state.horaInicial?.CLIENTE ?? 9*60),
+      endMin: null,
+      actionType: window.ACTION_TYPE_NORMAL || "NORMAL"
+    };
+    ensureDuration(task);
+    list.push(task);
+    touchTask(task);
+    state.project.view.selectedTaskId = task.id;
+    return task;
+  };
+
+  const deleteTask = (id)=>{
+    const list=getTaskList();
+    const toRemove=new Set();
+    const visit=(tid)=>{
+      toRemove.add(tid);
+      list.filter(t=>t.structureParentId===tid).forEach(child=>visit(child.id));
+    };
+    visit(id);
+    state.sessions.CLIENTE = list.filter(t=>!toRemove.has(t.id));
+    syncStaffSessions();
+    touch();
+  };
+
+  const selectTask = (id)=>{
+    state.project.view.selectedTaskId = id || null;
+  };
+
+  const formatTimeValue = (mins)=> mins==null?"":toHHMM(mins);
+
+  const parseTimeInput = (value)=>{
+    const str=String(value||"").trim();
+    if(!str) return null;
+    return toMin(str);
+  };
+
+  const labelForTask = (task)=> (task.actionName||"").trim() || "Sin nombre";
+
+  const sortedTasks = (tasks)=>{
+    const order=hierarchyOrder();
+    return tasks.slice().sort((a,b)=>{
+      const oa=order.get(a.id) ?? 0;
+      const ob=order.get(b.id) ?? 0;
+      if(oa!==ob) return oa-ob;
+      const ra=RELATION_ORDER[a.structureRelation] ?? 5;
+      const rb=RELATION_ORDER[b.structureRelation] ?? 5;
+      return ra-rb;
+    });
+  };
+
+  const renderCatalog = (container, tasks, selectedId)=>{
+    container.innerHTML="";
+    const toolbar=el("div","catalog-toolbar");
+    const addBtn=el("button","btn primary full","+ Nuevo hito");
+    addBtn.onclick=()=>{ createTask({relation:"milestone"}); renderClient(); };
+    toolbar.appendChild(addBtn);
+    container.appendChild(toolbar);
+
+    const grouped=[
+      { key:"pending", title:"Falta info", filter:(t)=>!isTaskComplete(t) },
+      { key:"complete", title:"Completa", filter:(t)=>isTaskComplete(t) }
+    ];
+
+    grouped.forEach(group=>{
+      const sec=el("div","catalog-section");
+      const head=el("div","catalog-title",`${group.title}`);
+      sec.appendChild(head);
+      const list=sortedTasks(tasks.filter(group.filter));
+      if(!list.length){
+        sec.appendChild(el("div","mini muted","Sin tareas"));
+      }else{
+        list.forEach(task=>{
+          const item=el("button","catalog-item",labelForTask(task));
+          if(task.id===selectedId) item.classList.add("active");
+          const relationLabel=RELATION_LABEL[task.structureRelation] || "Tarea";
+          item.appendChild(el("span","relation-tag",relationLabel));
+          item.onclick=()=>{ selectTask(task.id); renderClient(); };
+          const path=getBreadcrumb(task);
+          if(path.length>1){
+            const trail=path.slice(0,-1).map(node=>labelForTask(node)).join(" · ");
+            item.appendChild(el("div","mini muted",trail));
+          }
+          sec.appendChild(item);
+        });
+      }
+      container.appendChild(sec);
+    });
+  };
+
+  const renderMaterials = (task)=>{
+    const wrap=el("div","materials-section");
+    wrap.appendChild(el("h4",null,"Materiales"));
+    const table=el("div","materials-list");
+    if(!task.materiales.length){
+      table.appendChild(el("div","mini muted","Sin materiales"));
+    }
+    task.materiales.forEach((mat,idx)=>{
+      const row=el("div","material-row");
+      const sel=el("select","input");
+      const opt0=el("option",null,"- seleccionar -"); opt0.value=""; sel.appendChild(opt0);
+      (state.materialTypes||[]).forEach(mt=>{
+        const opt=el("option",null,mt.nombre||"Material"); opt.value=mt.id; if(mt.id===mat.materialTypeId) opt.selected=true; sel.appendChild(opt);
+      });
+      sel.onchange=()=>{ task.materiales[idx].materialTypeId = sel.value||null; touchTask(task); renderClient(); };
+      const qty=el("input","input"); qty.type="number"; qty.min="0"; qty.step="1"; qty.value=String(mat.cantidad||0);
+      qty.onchange=()=>{ task.materiales[idx].cantidad = Number(qty.value)||0; touchTask(task); };
+      const del=el("button","btn small", "Quitar");
+      del.onclick=()=>{ task.materiales.splice(idx,1); touchTask(task); renderClient(); };
+      row.appendChild(sel); row.appendChild(qty); row.appendChild(del);
+      table.appendChild(row);
+    });
+    const add=el("button","btn small", "Añadir material");
+    add.onclick=()=>{ task.materiales.push({materialTypeId:null,cantidad:0}); touchTask(task); renderClient(); };
+    wrap.appendChild(table);
+    wrap.appendChild(add);
+    return wrap;
+  };
+
+  const renderStaffPicker = (task)=>{
+    const wrap=el("div","staff-section");
+    wrap.appendChild(el("h4",null,"Asignación a staff"));
+    const list=el("div","staff-picker");
+    if(!(state.staff||[]).length){
+      list.appendChild(el("div","mini muted","Añade miembros del staff desde la barra lateral."));
+    }
+    (state.staff||[]).forEach(st=>{
+      const btn=el("button","staff-toggle",st.nombre||st.id);
+      if((task.assignedStaffIds||[]).includes(st.id)) btn.classList.add("active");
+      btn.onclick=()=>{
+        const current=new Set(task.assignedStaffIds||[]);
+        if(current.has(st.id)) current.delete(st.id); else current.add(st.id);
+        task.assignedStaffIds=Array.from(current);
+        touchTask(task);
+        renderClient();
+      };
+      list.appendChild(btn);
+    });
+    wrap.appendChild(list);
+    return wrap;
+  };
+
+  const renderChildSection = (task, relation, label)=>{
+    const block=el("div","child-block");
+    const header=el("div","child-header");
+    header.appendChild(el("h4",null,label));
+    const add=el("button","btn small",`+${label}`);
+    add.onclick=()=>{ createTask({ parentId:task.id, relation }); renderClient(); };
+    header.appendChild(add);
+    block.appendChild(header);
+    const children=getTaskChildren(task.id).filter(ch=>ch.structureRelation===relation);
+    if(!children.length){
+      block.appendChild(el("div","mini muted","Sin tareas"));
+    }else{
+      const list=el("div","child-list");
+      children.forEach(ch=>{
+        const item=el("button","child-item",labelForTask(ch));
+        if(!isTaskComplete(ch)) item.classList.add("pending");
+        item.onclick=()=>{ selectTask(ch.id); renderClient(); };
+        list.appendChild(item);
+      });
+      block.appendChild(list);
+    }
+    return block;
+  };
+
+  const renderTaskCard = (container, task)=>{
+    container.innerHTML="";
+    if(!task){
+      container.appendChild(el("div","empty-card","Selecciona una tarea o crea un nuevo hito."));
+      return;
+    }
+    applyTaskDefaults(task);
+
+    const header=el("div","task-header");
+    const title=el("h2","task-title", labelForTask(task));
+    header.appendChild(title);
+    const chips=el("div","task-chips");
+    const relationChip=el("span","relation-chip",RELATION_LABEL[task.structureRelation]||"Tarea");
+    chips.appendChild(relationChip);
+    const statusChip=el("span","status-chip", isTaskComplete(task)?"Completa":"Falta info");
+    statusChip.classList.add(isTaskComplete(task)?"ok":"warn");
+    chips.appendChild(statusChip);
+    header.appendChild(chips);
+    container.appendChild(header);
+
+    const breadcrumb=el("div","task-breadcrumb");
+    const path=getBreadcrumb(task);
+    path.forEach((node,idx)=>{
+      const btn=el("button","crumb", labelForTask(node));
+      if(idx===path.length-1){ btn.disabled=true; }
+      btn.onclick=()=>{ selectTask(node.id); renderClient(); };
+      breadcrumb.appendChild(btn);
+      if(idx<path.length-1) breadcrumb.appendChild(el("span","crumb-sep","›"));
+    });
+    container.appendChild(breadcrumb);
+
+    const form=el("div","task-form");
+    const nameRow=el("div","field-row");
+    nameRow.appendChild(el("label",null,"Nombre"));
+    const nameInput=el("input","input"); nameInput.type="text"; nameInput.value=task.actionName||"";
+    nameInput.oninput=()=>{ task.actionName=nameInput.value; title.textContent=labelForTask(task); };
+    nameInput.onblur=()=>{ touchTask(task); renderClient(); };
+    nameRow.appendChild(nameInput);
+    form.appendChild(nameRow);
+
+    const durationRow=el("div","field-row");
+    durationRow.appendChild(el("label",null,"Duración (min)"));
+    const durInput=el("input","input"); durInput.type="number"; durInput.min="5"; durInput.step="5"; durInput.value=String(task.durationMin||60);
+    durInput.onchange=()=>{
+      const v=Math.max(5, Math.round(Number(durInput.value)||60));
+      task.durationMin=v;
+      if(task.startMin!=null){ task.endMin = task.startMin + v; }
+      touchTask(task);
+      renderClient();
+    };
+    durationRow.appendChild(durInput);
+    form.appendChild(durationRow);
+
+    if(task.structureRelation==="milestone"){
+      const timeRow=el("div","field-row");
+      timeRow.appendChild(el("label",null,"Hora"));
+      const timeInput=el("input","input"); timeInput.type="time"; timeInput.value=formatTimeValue(task.startMin);
+      timeInput.onchange=()=>{
+        const v=parseTimeInput(timeInput.value);
+        task.startMin=v;
+        if(v==null){ task.endMin=null; }
+        else task.endMin=v + Math.max(5, Number(task.durationMin)||60);
+        touchTask(task);
+        renderClient();
+      };
+      timeRow.appendChild(timeInput);
+      form.appendChild(timeRow);
+    }else{
+      const limitRow=el("div","field-row");
+      if(task.structureRelation==="post"){
+        limitRow.appendChild(el("label",null,"Límite tarde"));
+        const limitInput=el("input","input"); limitInput.type="time"; limitInput.value=formatTimeValue(task.limitLateMin);
+        limitInput.onchange=()=>{
+          task.limitLateMin=parseTimeInput(limitInput.value);
+          touchTask(task);
+          renderClient();
+        };
+        limitRow.appendChild(limitInput);
+      }else{
+        limitRow.appendChild(el("label",null,"Límite temprano"));
+        const limitInput=el("input","input"); limitInput.type="time"; limitInput.value=formatTimeValue(task.limitEarlyMin);
+        limitInput.onchange=()=>{
+          task.limitEarlyMin=parseTimeInput(limitInput.value);
+          touchTask(task);
+          renderClient();
+        };
+        limitRow.appendChild(limitInput);
+      }
+      form.appendChild(limitRow);
+
+      const startRow=el("div","field-row");
+      startRow.appendChild(el("label",null,"Hora exacta (opcional)"));
+      const startInput=el("input","input"); startInput.type="time"; startInput.value=formatTimeValue(task.startMin);
+      startInput.onchange=()=>{
+        const v=parseTimeInput(startInput.value);
+        task.startMin=v;
+        if(v==null){ task.endMin=null; }
+        else task.endMin=v + Math.max(5, Number(task.durationMin)||60);
+        touchTask(task);
+        renderClient();
+      };
+      startRow.appendChild(startInput);
+      form.appendChild(startRow);
+    }
+
+    const locRow=el("div","field-row");
+    locRow.appendChild(el("label",null,"Localización"));
+    const locSelect=el("select","input");
+    const optEmpty=el("option",null,"- seleccionar -"); optEmpty.value=""; locSelect.appendChild(optEmpty);
+    (state.locations||[]).forEach(loc=>{
+      const opt=el("option",null,loc.nombre||"Localización"); opt.value=loc.id; if(loc.id===task.locationId) opt.selected=true; locSelect.appendChild(opt);
+    });
+    locSelect.disabled = task.locationApplies!==true;
+    locSelect.onchange=()=>{ task.locationId = locSelect.value||null; touchTask(task); renderClient(); };
+    locRow.appendChild(locSelect);
+    const locToggle=el("label","check");
+    const chk=el("input"); chk.type="checkbox"; chk.checked=!task.locationApplies;
+    chk.onchange=()=>{ task.locationApplies = !chk.checked; if(!task.locationApplies) task.locationId=null; touchTask(task); renderClient(); };
+    locToggle.appendChild(chk);
+    locToggle.appendChild(el("span",null,"Sin localización"));
+    locRow.appendChild(locToggle);
+    form.appendChild(locRow);
+
+    const notesRow=el("div","field-row");
+    notesRow.appendChild(el("label",null,"Notas"));
+    const notes=el("textarea","input"); notes.rows=4; notes.value=task.comentario||"";
+    notes.oninput=()=>{ task.comentario=notes.value; };
+    notes.onblur=()=>{ touchTask(task); };
+    notesRow.appendChild(notes);
+    form.appendChild(notesRow);
+
+    container.appendChild(form);
+    container.appendChild(renderMaterials(task));
+    container.appendChild(renderStaffPicker(task));
+    container.appendChild(renderChildSection(task,"pre","Pre"));
+    container.appendChild(renderChildSection(task,"parallel","Paralela"));
+    container.appendChild(renderChildSection(task,"post","Post"));
+
+    const danger=el("button","btn danger", "Eliminar tarea");
+    danger.onclick=()=>{
+      if(confirm("¿Eliminar esta tarea y sus dependientes?")){
+        const parentId=task.structureParentId;
+        deleteTask(task.id);
+        if(parentId){
+          selectTask(parentId);
+        }else{
+          const next=getTaskList()[0];
+          selectTask(next?next.id:null);
+        }
+        renderClient();
+      }
+    };
+    container.appendChild(danger);
+  };
+
+  const getVisibleTasks = ()=>{
+    const tasks=getTaskList();
+    const activeTab=state.project.view.lastTab;
+    if(activeTab && activeTab!=="CLIENTE"){
+      return tasks.filter(t=>(t.assignedStaffIds||[]).includes(activeTab));
+    }
+    return tasks;
+  };
+
+  window.renderClient = ()=>{
+    ensureViewDefaults();
+    const root=document.getElementById("clienteView");
+    if(!root) return;
+    const tasks=getTaskList();
+    const visible=getVisibleTasks();
+    let selectedId=state.project.view.selectedTaskId;
+    if(selectedId && !tasks.find(t=>t.id===selectedId)) selectedId=null;
+    if(!selectedId){
+      const fallback=(visible[0]||tasks[0])?.id || null;
+      selectedId=fallback;
+      state.project.view.selectedTaskId=selectedId;
+    }
+    if(selectedId && visible.length && !visible.some(t=>t.id===selectedId)){
+      selectedId=visible[0].id;
+      state.project.view.selectedTaskId=selectedId;
+    }
+    const selectedTask = selectedId ? getTaskById(selectedId) : null;
+    root.innerHTML="";
+    const layout=el("div","client-layout");
+    const catalog=el("div","task-catalog");
+    const card=el("div","task-card");
+    layout.appendChild(catalog);
+    layout.appendChild(card);
+    root.appendChild(layout);
+
+    renderCatalog(catalog, visible.length?visible:tasks, selectedId);
+    renderTaskCard(card, selectedTask);
+  };
+
+  const collectPersons = ()=>{
+    const persons=[];
+    const roots=getRootTasks().filter(t=>t.startMin!=null && t.endMin!=null).sort((a,b)=>a.startMin-b.startMin);
+    persons.push({ id:"CLIENTE", nombre:"Cliente", tasks:roots });
+    const byStaff=new Map();
+    getTaskList().forEach(task=>{
+      (task.assignedStaffIds||[]).forEach(id=>{
+        if(!byStaff.has(id)) byStaff.set(id, []);
+        byStaff.get(id).push(task);
+      });
+    });
+    (state.staff||[]).forEach(st=>{
+      const arr=(byStaff.get(st.id)||[]).slice().sort((a,b)=>{
+        const sa=a.startMin??Infinity; const sb=b.startMin??Infinity;
+        if(sa!==sb) return sa-sb;
+        return (RELATION_ORDER[a.structureRelation]||0)-(RELATION_ORDER[b.structureRelation]||0);
+      });
+      persons.push({ id:st.id, nombre:st.nombre||st.id, tasks:arr });
+    });
+    return persons;
+  };
+
+  const colorForTask = (task)=> RELATION_COLOR[task.structureRelation] || "#60a5fa";
+
+  window.buildGantt = (cont)=>{
+    cont.innerHTML="";
+    const persons=collectPersons();
+    if(!persons.length){
+      cont.appendChild(el("div","mini","Sin tareas"));
+      return;
+    }
+    const wrap=el("div","gwrap");
+    const head=el("div","gantt-header"); head.appendChild(el("div",null,"Persona"));
+    const hours=el("div","gantt-hours"); for(let h=0;h<24;h++) hours.appendChild(el("div",null,String(h).padStart(2,"0")+":00"));
+    head.appendChild(hours); wrap.appendChild(head);
+    persons.forEach(person=>{
+      const row=el("div","gantt-row");
+      row.appendChild(el("div",null,person.nombre));
+      const track=el("div","gantt-track");
+      (person.tasks||[]).forEach(task=>{
+        if(task.startMin==null || task.endMin==null) return;
+        const seg=el("div","seg");
+        seg.style.left=((task.startMin/1440)*100)+"%";
+        seg.style.width=(((task.endMin-task.startMin)/1440)*100)+"%";
+        seg.style.background=colorForTask(task);
+        seg.title=`${toHHMM(task.startMin)}-${toHHMM(task.endMin)} · ${labelForTask(task)}`;
+        seg.appendChild(el("div","meta",labelForTask(task)));
+        track.appendChild(seg);
+      });
+      row.appendChild(track); wrap.appendChild(row);
+    });
+    cont.appendChild(wrap);
+  };
+
+  const materialSummary = ()=>{
+    const totals=new Map();
+    getTaskList().forEach(task=>{
+      (task.materiales||[]).forEach(m=>{
+        const key=m.materialTypeId;
+        if(!key) return;
+        totals.set(key,(totals.get(key)||0)+Number(m.cantidad||0));
+      });
+    });
+    return totals;
+  };
+
+  window.renderMateriales = (cont)=>{
+    cont.innerHTML="";
+    const totals=materialSummary();
+    const tbl=el("table");
+    const thead=el("thead"); const trh=el("tr");
+    ["Material","Total"].forEach(h=>trh.appendChild(el("th",null,h))); thead.appendChild(trh); tbl.appendChild(thead);
+    const tb=el("tbody");
+    if(!totals.size){
+      const tr=el("tr"); const td=el("td"); td.colSpan=2; td.textContent="Sin materiales"; tr.appendChild(td); tb.appendChild(tr);
+    }else{
+      totals.forEach((qty,id)=>{
+        const tr=el("tr");
+        const name=(state.materialTypes||[]).find(mt=>mt.id===id)?.nombre || "Material";
+        tr.appendChild(el("td",null,name));
+        tr.appendChild(el("td",null,String(qty)));
+        tb.appendChild(tr);
+      });
+    }
+    tbl.appendChild(tb); cont.appendChild(tbl);
+  };
+
+  window.exportCSV = ()=>{
+    const totals=materialSummary();
+    const rows=[["Material","Total"]];
+    totals.forEach((qty,id)=>{
+      const name=(state.materialTypes||[]).find(mt=>mt.id===id)?.nombre || "Material";
+      rows.push([name, String(qty)]);
+    });
+    const csv=rows.map(r=>r.map(x=>`"${String(x).replace(/"/g,'""')}"`).join(",")).join("\r\n");
+const a=document.createElement("a");
+    a.href="data:text/csv;charset=utf-8,"+encodeURIComponent(csv);
+    a.download="materiales.csv";
+    a.click();
+  };
+
+  window.buildCards = (cont)=>{
+    cont.innerHTML="";
+    const persons=collectPersons();
+    const tools=el("div","row"); const pr=el("button","btn small","Imprimir"); pr.onclick=()=>window.print(); tools.appendChild(pr); cont.appendChild(tools);
+    const list=el("div","cardlist");
+    persons.forEach(person=>{
+      const card=el("div","card"); card.appendChild(el("h4",null,person.nombre));
+      const body=el("div");
+      (person.tasks||[]).forEach(task=>{
+        const item=el("div","item");
+        const time=(task.startMin!=null && task.endMin!=null) ? `${toHHMM(task.startMin)}–${toHHMM(task.endMin)}` : "Sin hora";
+        item.appendChild(el("div",null,time));
+        const locName=(state.locations||[]).find(l=>l.id===task.locationId)?.nombre || "";
+        const desc=[labelForTask(task)];
+        if(locName) desc.push(locName);
+        item.appendChild(el("div",null,desc.join(" · ")));
+        body.appendChild(item);
+        if(task.materiales?.length){
+          const txt=task.materiales.filter(m=>m.materialTypeId).map(m=>{
+            const name=(state.materialTypes||[]).find(mt=>mt.id===m.materialTypeId)?.nombre || "Material";
+            return `${name} x ${m.cantidad||0}`;
+          }).join(", ");
+          if(txt) body.appendChild(el("div","mini","Materiales: "+txt));
+        }
+        if(task.comentario){ body.appendChild(el("div","mini","Notas: "+task.comentario)); }
+      });
+      if(!person.tasks?.length){
+        body.appendChild(el("div","mini muted","Sin tareas"));
+      }
+      card.appendChild(body); list.appendChild(card);
+    });
+    cont.appendChild(list);
+  };
+
+  window.buildSummary = (cont)=>{
+    cont.innerHTML="";
+    const persons=collectPersons();
+    const tbl=el("table"); const thead=el("thead"); const trh=el("tr");
+    ["Persona","Acciones","Min totales","Sin hora"].forEach(h=>trh.appendChild(el("th",null,h))); thead.appendChild(trh); tbl.appendChild(thead);
+    const tb=el("tbody");
+    persons.forEach(person=>{
+      const arr=person.tasks||[];
+      let mins=0; let unscheduled=0;
+      arr.forEach(task=>{
+        if(task.startMin!=null && task.endMin!=null){ mins+=task.endMin-task.startMin; }
+        else unscheduled++;
+      });
+      const tr=el("tr");
+      tr.appendChild(el("td",null,person.nombre));
+      tr.appendChild(el("td",null,String(arr.length)));
+      tr.appendChild(el("td",null,String(mins)));
+      tr.appendChild(el("td",null,unscheduled?String(unscheduled):"-"));
+      tb.appendChild(tr);
+    });
+    tbl.appendChild(tb); cont.appendChild(tbl);
+  };
+
+  window.ensureDefaults = ()=>{
+    originalEnsureDefaults();
+    ensureViewDefaults();
+  };
+
+  window.ensureLinkFields = ()=>{
+    originalEnsureLinkFields();
+    ensureViewDefaults();
+    getTaskList();
+    syncStaffSessions();
+  };
+
+  document.addEventListener("DOMContentLoaded", ()=>{
+    ensureViewDefaults();
+    syncStaffSessions();
+    const tabs=document.getElementById("personTabs");
+    if(tabs){
+      tabs.innerHTML="";
+      const btn=el("button","tab active","Horario del cliente");
+      btn.onclick=()=>{ state.project.view.lastTab="CLIENTE"; renderClient(); };
+      tabs.appendChild(btn);
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <div class="field"><label>Nombre</label><input id="pNombre" class="input" placeholder="Nombre"></div>
         <div class="field"><label>Fecha (un dia)</label><input id="pFecha" class="input" placeholder="aaaa-mm-dd"></div>
         <div class="field"><label>Zona horaria</label><input id="pTz" class="input" placeholder="Europe/Madrid"></div>
-        <div class="mini">Columna "#" selecciona. El boton de cada pestaña crea la accion.</div>
+        <div class="mini">Construye el horario desde el catálogo de hitos y tareas. Asigna staff desde cada tarjeta.</div>
       </div>
 
       <div class="section">
@@ -63,5 +63,6 @@
   </div>
 
   <script src="./assets/app.bundle.js"></script>
+  <script src="./assets/new-ui.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a client-centric scheduling module that handles hierarchical tasks, staff assignment, and catalog/card rendering
- sync gantt, card, summary, and material exports with the new task data and autosave flows
- refresh the layout styles, HTML bootstrap, and README instructions to match the updated workflow

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d419df497c832a9a03c19eb954c880